### PR TITLE
Hardened Argo Workflows 3.4.6 Release

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -368,6 +368,10 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 	mux.HandleFunc("/api/", func(w http.ResponseWriter, r *http.Request) {
 		// we must delete this header for API request to prevent "stream terminated by RST_STREAM with error code: PROTOCOL_ERROR" error
 		r.Header.Del("Connection")
+		if r.URL.Path == "/api/v1/info" {
+			w.Header().Set("Access-Control-Allow-Origin", as.accessControlAllowOrigin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
 		webhookInterceptor(w, r, gwmux)
 	})
 

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -304,8 +304,8 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		Name:     "authorization",
 		Path:     s.baseHRef,
 		Expires:  time.Now().Add(s.expiry),
-		SameSite: http.SameSiteStrictMode,
-		Secure:   s.secure,
+		SameSite: http.SameSiteNoneMode,
+		Secure:   true,
 	})
 	redirect := s.baseHRef
 

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -3,7 +3,12 @@ package static
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
+)
+
+const (
+	frameAncestorEnvVarName = "FRAME_ANCESTOR"
 )
 
 type FilesServer struct {
@@ -29,9 +34,9 @@ func (s *FilesServer) ServerFiles(w http.ResponseWriter, r *http.Request) {
 		w = &responseRewriter{ResponseWriter: w, old: []byte(`<base href="/">`), new: []byte(fmt.Sprintf(`<base href="%s">`, s.baseHRef))}
 	}
 
-	if s.xframeOpts != "" {
-		w.Header().Set("X-Frame-Options", s.xframeOpts)
-	}
+	// if s.xframeOpts != "" {
+	// 	w.Header().Set("X-Frame-Options", s.xframeOpts)
+	// }
 
 	if s.corsAllowOrigin != "" {
 		w.Header().Set("Access-Control-Allow-Origin", s.corsAllowOrigin)
@@ -44,8 +49,10 @@ func (s *FilesServer) ServerFiles(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	frameAncestor := os.Getenv(frameAncestorEnvVarName)
 	// `data:` is need for Monaco editors wiggly red lines
-	w.Header().Set("Content-Security-Policy", "default-src 'self' 'unsafe-inline'; img-src 'self' data:")
+	csp := fmt.Sprintf("default-src 'self' 'unsafe-inline'; img-src 'self'; frame-ancestors %s", frameAncestor)
+	w.Header().Set("Content-Security-Policy", csp)
 	if s.hsts {
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 	}

--- a/ui/src/app/login/components/login.tsx
+++ b/ui/src/app/login/components/login.tsx
@@ -11,7 +11,7 @@ const logout = () => {
 };
 const user = (token: string) => {
     const path = uiUrl('');
-    document.cookie = 'authorization=' + token + ';SameSite=Strict;path=' + path;
+    document.cookie = 'authorization=' + token + ';SameSite=None;Secure=true;path=' + path;
     document.location.href = path;
 };
 const getRedirect = (): string => {


### PR DESCRIPTION
## Argo Workflows Quickstart

This setup process uses the default quickstart installation of Argo Workflows provided in the [main Github repository](https://raw.githubusercontent.com/argoproj/argo-workflows/master/manifests/quick-start-postgres.yaml), with a few minor changes.

To provide a unified, single-interface experience, GreenOps embeds the Argo Workflows UI via iframe. To make this as secure as possible, https://github.com/GreenOpsInc/argo-workflows/pull/3 to the Argo WF server:

frame-ancestors was added in the Content-Security-Policy to ensure that only GreenOps can embed Argo Workflows via iframe.
The Argo Workflow cookie settings are set to SameSite=None;Secure. Access-Control-Allow-Origin should also be set to the GreenOps URL. This allows only GreenOps to embed Argo Workflows, while ensuring that other third parties cannot make requests or interact with Argo Workflows.
All the changes made to the Argo Workflows server can be seen https://github.com/GreenOpsInc/argo-workflows/pull/3.

The quickstart YAML file uses the updated Argo Workflows server image and leaves an empty space for the FRAME_ANCESTOR in the [environment variables section](https://github.com/GreenOpsInc/greenops-helm-chart/blob/main/argo-workflows/quick-start-postgres.yaml#L1708) and --access-control-allow-origin in the [arguments section](https://github.com/GreenOpsInc/greenops-helm-chart/blob/main/argo-workflows/quick-start-postgres.yaml#L1702).